### PR TITLE
feat: harden phase1 gap detection and go/no-go evaluation

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,12 +9,13 @@ on:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
 

--- a/README.md
+++ b/README.md
@@ -33,5 +33,18 @@ uv run python -m autonomous_discovery.gap_detector.pilot_cli --top-k 20
 
 Artifacts are written under `data/processed/`:
 - `gap_candidates.jsonl`
-- `top20_label_template.csv`
+- `top{K}_label_template.csv` (for example `top20_label_template.csv`)
 - `phase1_metrics.json`
+
+After labeling `label_non_trivial` in the CSV, compute go/no-go metrics:
+
+```bash
+uv run python -m autonomous_discovery.gap_detector.evaluate_cli \
+  --metrics-path data/processed/phase1_metrics.json \
+  --labels-csv data/processed/top20_label_template.csv \
+  --top-k 20
+```
+
+This updates `phase1_metrics.json` with `topk_precision`, `detection_rate`,
+`non_trivial_count`, and `go_no_go_status`. For `--top-k 20`, a compatibility
+key `top20_precision` is also populated.

--- a/src/autonomous_discovery/gap_detector/__init__.py
+++ b/src/autonomous_discovery/gap_detector/__init__.py
@@ -5,6 +5,7 @@ from autonomous_discovery.gap_detector.analogical import (
     GapCandidate,
     GapDetectorConfig,
 )
+from autonomous_discovery.gap_detector.evaluate_cli import main as evaluate_metrics_cli_main
 from autonomous_discovery.gap_detector.evaluation import (
     build_topk_label_template_rows,
     compute_detection_rate,
@@ -22,6 +23,7 @@ __all__ = [
     "build_topk_label_template_rows",
     "compute_detection_rate",
     "compute_topk_precision",
+    "evaluate_metrics_cli_main",
     "read_gap_report",
     "run_phase1_pilot",
     "scan_seed_annotations",

--- a/src/autonomous_discovery/gap_detector/evaluate_cli.py
+++ b/src/autonomous_discovery/gap_detector/evaluate_cli.py
@@ -1,0 +1,129 @@
+"""CLI for computing Phase 1 go/no-go metrics from labeled top-k gaps."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+from autonomous_discovery.config import ProjectConfig
+from autonomous_discovery.gap_detector.evaluation import (
+    compute_detection_rate,
+    compute_topk_precision,
+)
+
+POSITIVE_LABELS = {"1", "true", "yes", "y"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Evaluate labeled top-k gap candidates.")
+    parser.add_argument("--metrics-path", type=Path, required=True)
+    parser.add_argument("--labels-csv", type=Path, required=True)
+    parser.add_argument("--top-k", type=int, default=None)
+    return parser
+
+
+def _is_non_trivial(label_value: str) -> bool:
+    return label_value.strip().lower() in POSITIVE_LABELS
+
+
+def _module_proxy(decl_name: str) -> str:
+    parts = [part for part in decl_name.split(".") if part]
+    if len(parts) >= 3:
+        return ".".join(parts[:2])
+    if parts:
+        return parts[0]
+    return "<unknown>"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = ProjectConfig()
+
+    try:
+        metrics = json.loads(args.metrics_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"Input file not found: {args.metrics_path}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Invalid JSON in metrics file: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        with args.labels_csv.open(encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+    except FileNotFoundError:
+        print(f"Input file not found: {args.labels_csv}", file=sys.stderr)
+        return 1
+
+    if rows and "label_non_trivial" not in rows[0]:
+        print("Labels CSV must include 'label_non_trivial' column", file=sys.stderr)
+        return 1
+    if rows and "source_decl" not in rows[0]:
+        print("Labels CSV must include 'source_decl' column", file=sys.stderr)
+        return 1
+
+    try:
+        requested_top_k = args.top_k if args.top_k is not None else int(metrics.get("top_k", 20))
+    except (TypeError, ValueError):
+        print("Invalid top_k value in metrics file", file=sys.stderr)
+        return 1
+    if requested_top_k <= 0:
+        print("top_k must be a positive integer", file=sys.stderr)
+        return 1
+
+    top_rows = rows[:requested_top_k]
+    labels = [_is_non_trivial(row.get("label_non_trivial") or "") for row in top_rows]
+    non_trivial_count = sum(1 for label in labels if label)
+    topk_precision = compute_topk_precision(labels)
+
+    evaluated_modules = {_module_proxy(row.get("source_decl") or "") for row in top_rows}
+    non_trivial_modules = {
+        _module_proxy(row.get("source_decl") or "")
+        for row, is_non_trivial in zip(top_rows, labels, strict=True)
+        if is_non_trivial
+    }
+    evaluated_module_count = len(evaluated_modules)
+    modules_with_non_trivial_gaps_count = len(non_trivial_modules)
+    detection_rate = compute_detection_rate(
+        non_trivial_count=modules_with_non_trivial_gaps_count,
+        total_candidates=evaluated_module_count,
+    )
+    non_trivial_candidate_rate = compute_detection_rate(
+        non_trivial_count=non_trivial_count,
+        total_candidates=len(top_rows),
+    )
+
+    primary_ok = detection_rate >= config.min_detection_rate
+    secondary_ok = topk_precision >= config.min_top20_precision
+    absolute_ok = non_trivial_count >= config.min_nontrivial_gaps
+    go_no_go_status = "go" if absolute_ok and (primary_ok or secondary_ok) else "no_go"
+
+    if requested_top_k == 20:
+        metrics["top20_precision"] = topk_precision
+    else:
+        metrics.pop("top20_precision", None)
+    metrics["topk_precision"] = topk_precision
+    metrics["detection_rate"] = detection_rate
+    metrics["detection_rate_basis"] = "evaluated_module_proxy_rate"
+    metrics["non_trivial_candidate_rate"] = non_trivial_candidate_rate
+    metrics["non_trivial_count"] = non_trivial_count
+    metrics["evaluated_module_count"] = evaluated_module_count
+    metrics["modules_with_non_trivial_gaps_count"] = modules_with_non_trivial_gaps_count
+    metrics["go_no_go_checks"] = {
+        "primary_detection_rate_ok": primary_ok,
+        "secondary_topk_precision_ok": secondary_ok,
+        "minimum_non_trivial_count_ok": absolute_ok,
+    }
+    metrics["go_no_go_status"] = go_no_go_status
+    args.metrics_path.write_text(
+        json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/autonomous_discovery/gap_detector/pilot.py
+++ b/src/autonomous_discovery/gap_detector/pilot.py
@@ -31,11 +31,11 @@ def run_phase1_pilot(
     graph = MathlibGraph.from_raw_data(premises, declarations)
 
     detector = AnalogicalGapDetector(config=GapDetectorConfig(top_k=top_k))
-    candidates = detector.detect(graph, top_k=top_k)
+    candidates = detector.detect(graph)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     candidates_path = output_dir / "gap_candidates.jsonl"
-    labels_path = output_dir / "top20_label_template.csv"
+    labels_path = output_dir / f"top{top_k}_label_template.csv"
     metrics_path = output_dir / "phase1_metrics.json"
 
     write_gap_report(candidates, candidates_path)
@@ -48,9 +48,13 @@ def run_phase1_pilot(
         "candidates_path": str(candidates_path),
         "labels_path": str(labels_path),
         "metrics_path": str(metrics_path),
-        "top20_precision": None,
+        "topk_precision": None,
         "detection_rate": None,
+        "non_trivial_count": None,
+        "go_no_go_status": "pending",
     }
+    if top_k == 20:
+        summary["top20_precision"] = None
     metrics_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return summary
 

--- a/src/autonomous_discovery/gap_detector/pilot_cli.py
+++ b/src/autonomous_discovery/gap_detector/pilot_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from autonomous_discovery.config import ProjectConfig
@@ -23,12 +24,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    run_phase1_pilot(
-        premises_path=args.premises_path,
-        decl_types_path=args.decl_types_path,
-        output_dir=args.output_dir,
-        top_k=args.top_k,
-    )
+    try:
+        run_phase1_pilot(
+            premises_path=args.premises_path,
+            decl_types_path=args.decl_types_path,
+            output_dir=args.output_dir,
+            top_k=args.top_k,
+        )
+    except FileNotFoundError as exc:
+        print(f"Input file not found: {exc.filename}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/autonomous_discovery/gap_detector/seeds.py
+++ b/src/autonomous_discovery/gap_detector/seeds.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -16,6 +17,9 @@ class SeedHint:
     content: str
 
 
+TODO_WORD_RE = re.compile(r"\btodo\b", flags=re.IGNORECASE)
+
+
 def scan_seed_annotations(paths: list[Path]) -> list[SeedHint]:
     """Scan Lean files for TODO/sorry markers."""
     hints: list[SeedHint] = []
@@ -24,7 +28,7 @@ def scan_seed_annotations(paths: list[Path]) -> list[SeedHint]:
         for index, line in enumerate(text.splitlines(), start=1):
             stripped = line.strip()
             lowered = stripped.lower()
-            if "todo" in lowered:
+            if TODO_WORD_RE.search(stripped):
                 hints.append(
                     SeedHint(
                         file_path=str(path),

--- a/tests/evaluation/test_evaluate_cli.py
+++ b/tests/evaluation/test_evaluate_cli.py
@@ -1,0 +1,182 @@
+import csv
+import json
+from pathlib import Path
+
+from autonomous_discovery.gap_detector.evaluate_cli import main
+
+
+def _write_metrics(path: Path, top_k: int = 5) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "candidate_count": top_k,
+                "top_k": top_k,
+                "output_dir": str(path.parent),
+                "candidates_path": str(path.parent / "gap_candidates.jsonl"),
+                "labels_path": str(path.parent / f"top{top_k}_label_template.csv"),
+                "metrics_path": str(path),
+                "topk_precision": None,
+                "detection_rate": None,
+                "non_trivial_count": None,
+                "go_no_go_status": "pending",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_labels(path: Path, labels: list[str], source_decls: list[str] | None = None) -> None:
+    fieldnames = [
+        "missing_decl",
+        "source_decl",
+        "target_family",
+        "score",
+        "label_non_trivial",
+        "notes",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for idx, label in enumerate(labels, start=1):
+            source_decl = (
+                source_decls[idx - 1] if source_decls is not None else f"Group.M{idx}.gap_{idx}"
+            )
+            writer.writerow(
+                {
+                    "missing_decl": f"Ring.gap_{idx}",
+                    "source_decl": source_decl,
+                    "target_family": "Ring.",
+                    "score": "0.5",
+                    "label_non_trivial": label,
+                    "notes": "",
+                }
+            )
+
+
+def test_evaluate_cli_updates_metrics(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "phase1_metrics.json"
+    labels_path = tmp_path / "top5_label_template.csv"
+    _write_metrics(metrics_path, top_k=5)
+    _write_labels(labels_path, labels=["yes", "1", "", "no", "false"])
+
+    code = main(
+        [
+            "--metrics-path",
+            str(metrics_path),
+            "--labels-csv",
+            str(labels_path),
+            "--top-k",
+            "5",
+        ]
+    )
+
+    assert code == 0
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert "top20_precision" not in metrics
+    assert metrics["topk_precision"] == 0.4
+    assert metrics["detection_rate"] == 0.4
+    assert metrics["detection_rate_basis"] == "evaluated_module_proxy_rate"
+    assert metrics["non_trivial_candidate_rate"] == 0.4
+    assert metrics["non_trivial_count"] == 2
+    assert metrics["evaluated_module_count"] == 5
+    assert metrics["modules_with_non_trivial_gaps_count"] == 2
+    assert metrics["go_no_go_status"] == "no_go"
+
+
+def test_evaluate_cli_marks_go_when_primary_or_secondary_and_absolute_pass(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "phase1_metrics.json"
+    labels_path = tmp_path / "top60_label_template.csv"
+    _write_metrics(metrics_path, top_k=60)
+    labels = ["yes"] * 40 + ["no"] * 20
+    # Keep all positive labels in one module so detection_rate fails but precision passes.
+    source_decls = (
+        ["Group.Core.same_module"] * 24
+        + ["Group.Core.same_module" for _ in range(16)]
+        + [f"Group.M{i}.gap_{i}" for i in range(20)]
+    )
+    _write_labels(labels_path, labels=labels, source_decls=source_decls)
+
+    code = main(
+        [
+            "--metrics-path",
+            str(metrics_path),
+            "--labels-csv",
+            str(labels_path),
+            "--top-k",
+            "60",
+        ]
+    )
+    assert code == 0
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["topk_precision"] == (40 / 60)
+    assert metrics["non_trivial_count"] == 40
+    assert metrics["detection_rate"] < 0.05
+    assert metrics["go_no_go_checks"]["primary_detection_rate_ok"] is False
+    assert metrics["go_no_go_checks"]["secondary_topk_precision_ok"] is True
+    assert metrics["go_no_go_checks"]["minimum_non_trivial_count_ok"] is True
+    assert metrics["go_no_go_status"] == "go"
+
+
+def test_evaluate_cli_populates_top20_precision_for_top20_runs(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "phase1_metrics.json"
+    labels_path = tmp_path / "top20_label_template.csv"
+    _write_metrics(metrics_path, top_k=20)
+    _write_labels(labels_path, labels=["yes"] * 20)
+
+    code = main(
+        [
+            "--metrics-path",
+            str(metrics_path),
+            "--labels-csv",
+            str(labels_path),
+            "--top-k",
+            "20",
+        ]
+    )
+    assert code == 0
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["top20_precision"] == 1.0
+    assert metrics["topk_precision"] == 1.0
+
+
+def test_evaluate_cli_reports_invalid_metrics_json(tmp_path: Path, capsys) -> None:
+    metrics_path = tmp_path / "phase1_metrics.json"
+    labels_path = tmp_path / "top5_label_template.csv"
+    metrics_path.write_text("{invalid json", encoding="utf-8")
+    _write_labels(labels_path, labels=["yes"])
+
+    code = main(
+        [
+            "--metrics-path",
+            str(metrics_path),
+            "--labels-csv",
+            str(labels_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "invalid json" in captured.err.lower()
+
+
+def test_evaluate_cli_reports_missing_required_csv_column(tmp_path: Path, capsys) -> None:
+    metrics_path = tmp_path / "phase1_metrics.json"
+    labels_path = tmp_path / "top5_label_template.csv"
+    _write_metrics(metrics_path, top_k=5)
+    labels_path.write_text(
+        "missing_decl,source_decl,target_family,score,notes\n"
+        "Ring.gap_1,Group.M1.gap_1,Ring.,0.5,\n",
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "--metrics-path",
+            str(metrics_path),
+            "--labels-csv",
+            str(labels_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "label_non_trivial" in captured.err

--- a/tests/gap_detector/test_analogical.py
+++ b/tests/gap_detector/test_analogical.py
@@ -65,10 +65,14 @@ Module.add : Prop
 def test_detects_missing_analogical_counterpart() -> None:
     graph = _build_graph()
     detector = AnalogicalGapDetector(
-        config=GapDetectorConfig(family_prefixes=("Group.", "Ring.", "Module."))
+        config=GapDetectorConfig(
+            family_prefixes=("Group.", "Ring.", "Module."),
+            min_cross_family_hits=0,
+            min_cross_family_overlap=0.0,
+        )
     )
 
-    gaps = detector.detect(graph, top_k=20)
+    gaps = detector.detect(graph)
     missing_names = {g.missing_decl for g in gaps}
 
     assert "Ring.one_mul" in missing_names
@@ -79,19 +83,128 @@ def test_respects_score_threshold() -> None:
     detector = AnalogicalGapDetector(
         config=GapDetectorConfig(
             family_prefixes=("Group.", "Ring.", "Module."),
+            min_cross_family_hits=0,
+            min_cross_family_overlap=0.0,
             min_score=1.01,
         )
     )
-    assert detector.detect(graph, top_k=20) == []
+    assert detector.detect(graph) == []
 
 
 def test_returns_ranked_results_with_expected_signals() -> None:
     graph = _build_graph()
-    detector = AnalogicalGapDetector()
-    gaps = detector.detect(graph, top_k=2)
+    detector = AnalogicalGapDetector(
+        config=GapDetectorConfig(
+            top_k=2,
+            min_cross_family_hits=0,
+            min_cross_family_overlap=0.0,
+        )
+    )
+    gaps = detector.detect(graph)
 
     assert len(gaps) == 2
     assert gaps[0].score >= gaps[1].score
     assert "dependency_overlap" in gaps[0].signals
     assert "source_pagerank" in gaps[0].signals
     assert "source_descendants" in gaps[0].signals
+    assert "cross_family_hits" in gaps[0].signals
+    assert "cross_family_total" in gaps[0].signals
+    assert "cross_family_overlap" in gaps[0].signals
+    assert "namespace_stem_match" in gaps[0].signals
+
+
+def test_filters_namespace_stem_mismatch_candidates() -> None:
+    premises_text = """\
+---
+Module.Basis.subset_extend
+  * Module.Basis.mk
+---
+Module.Basis.mk
+  * Module.add
+---
+Group.mul_assoc
+  * Group.mul
+---
+Group.mul
+  * HMul.hMul
+---
+Ring.mul_assoc
+  * Ring.mul
+---
+Ring.mul
+  * HMul.hMul
+---
+Module.add
+  * HAdd.hAdd
+"""
+    decl_text = """\
+---
+theorem
+Module.Basis.subset_extend
+Module.Basis.subset_extend : Prop
+---
+theorem
+Module.Basis.mk
+Module.Basis.mk : Prop
+---
+theorem
+Group.mul_assoc
+Group.mul_assoc : Prop
+---
+theorem
+Group.mul
+Group.mul : Prop
+---
+theorem
+Ring.mul_assoc
+Ring.mul_assoc : Prop
+---
+theorem
+Ring.mul
+Ring.mul : Prop
+---
+theorem
+Module.add
+Module.add : Prop
+---
+theorem
+HMul.hMul
+HMul.hMul : Prop
+---
+theorem
+HAdd.hAdd
+HAdd.hAdd : Prop
+"""
+    graph = MathlibGraph.from_raw_data(
+        parse_premises(premises_text),
+        parse_declaration_types(decl_text),
+    )
+    detector = AnalogicalGapDetector(
+        config=GapDetectorConfig(
+            family_prefixes=("Group.", "Ring.", "Module."),
+            min_cross_family_hits=1,
+            min_cross_family_overlap=0.0,
+            require_namespace_stem_match=True,
+            min_score=0.0,
+        )
+    )
+
+    gaps = detector.detect(graph)
+    missing_names = {g.missing_decl for g in gaps}
+
+    assert "Group.Basis.subset_extend" not in missing_names
+    assert "Ring.Basis.subset_extend" not in missing_names
+
+
+def test_detect_supports_backward_compatible_top_k_argument() -> None:
+    graph = _build_graph()
+    detector = AnalogicalGapDetector(
+        config=GapDetectorConfig(
+            top_k=5,
+            min_cross_family_hits=0,
+            min_cross_family_overlap=0.0,
+        )
+    )
+
+    gaps = detector.detect(graph, top_k=1)
+    assert len(gaps) == 1

--- a/tests/gap_detector/test_seeds.py
+++ b/tests/gap_detector/test_seeds.py
@@ -24,3 +24,17 @@ def bar : Nat := by
 
     todo = next(h for h in hints if h.kind == "todo")
     assert "strengthen hypothesis" in todo.content
+
+
+def test_scan_seed_annotations_ignores_todo_substring_inside_identifier(tmp_path) -> None:
+    lean_file = tmp_path / "Mathlib" / "Algebra" / "Identifier.lean"
+    lean_file.parent.mkdir(parents=True)
+    lean_file.write_text(
+        """\
+def pseudoTopologicalGroupTodoCounter : Nat := 1
+def done : Nat := 2
+"""
+    )
+
+    hints = scan_seed_annotations([lean_file])
+    assert hints == []

--- a/tests/integration/test_gap_detector_pipeline.py
+++ b/tests/integration/test_gap_detector_pipeline.py
@@ -61,3 +61,17 @@ OfNat.ofNat : Prop
     records = [json.loads(line) for line in output_path.read_text().splitlines() if line]
     assert records
     assert any(r["missing_decl"] == "Ring.one_mul" for r in records)
+
+
+def test_gap_detector_cli_reports_missing_input(capsys: pytest.CaptureFixture[str]) -> None:
+    code = main(
+        [
+            "--premises-path",
+            "does-not-exist-premises.txt",
+            "--decl-types-path",
+            "does-not-exist-decls.txt",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert code != 0
+    assert "not found" in captured.err.lower()

--- a/tests/integration/test_phase1_pilot_artifacts.py
+++ b/tests/integration/test_phase1_pilot_artifacts.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from autonomous_discovery.gap_detector.evaluate_cli import main as evaluate_main
 from autonomous_discovery.gap_detector.pilot import run_phase1_pilot
 
 
@@ -52,22 +53,55 @@ OfNat.ofNat : Prop
     )
 
     candidates_path = output_dir / "gap_candidates.jsonl"
-    labels_path = output_dir / "top20_label_template.csv"
+    labels_path = output_dir / "top5_label_template.csv"
     metrics_path = output_dir / "phase1_metrics.json"
 
     assert summary["candidate_count"] >= 1
     assert candidates_path.exists()
     assert labels_path.exists()
     assert metrics_path.exists()
+    lines = [line for line in candidates_path.read_text().splitlines() if line.strip()]
+    assert lines
+    for line in lines:
+        json.loads(line)
 
     with metrics_path.open() as f:
         metrics = json.load(f)
     assert "candidate_count" in metrics
     assert "top_k" in metrics
+    assert "topk_precision" in metrics
+    assert "detection_rate" in metrics
+    assert "non_trivial_count" in metrics
+    assert metrics["go_no_go_status"] == "pending"
 
-    with labels_path.open() as f:
+    with labels_path.open(encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
     assert rows
     assert {"missing_decl", "source_decl", "target_family", "label_non_trivial", "notes"} <= set(
         rows[0].keys()
     )
+
+    rows[0]["label_non_trivial"] = "yes"
+    with labels_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+
+    code = evaluate_main(
+        [
+            "--metrics-path",
+            str(metrics_path),
+            "--labels-csv",
+            str(labels_path),
+            "--top-k",
+            "5",
+        ]
+    )
+    assert code == 0
+
+    updated = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert "top20_precision" not in updated
+    assert updated["topk_precision"] > 0.0
+    assert updated["detection_rate"] > 0.0
+    assert updated["non_trivial_count"] >= 1
+    assert updated["go_no_go_status"] in {"go", "no_go"}

--- a/tests/integration/test_pilot_cli.py
+++ b/tests/integration/test_pilot_cli.py
@@ -1,0 +1,15 @@
+from autonomous_discovery.gap_detector.pilot_cli import main
+
+
+def test_pilot_cli_reports_missing_input(capsys) -> None:
+    code = main(
+        [
+            "--premises-path",
+            "does-not-exist-premises.txt",
+            "--decl-types-path",
+            "does-not-exist-decls.txt",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert code != 0
+    assert "not found" in captured.err.lower()


### PR DESCRIPTION
## Summary
- refine analogical gap detection with structural heuristics and backward-compatible top-k override
- add Phase 1 evaluation CLI to compute go/no-go metrics from labeled top-k outputs
- harden CLI error handling for missing/invalid inputs and reduce seed-scan false positives
- update pilot artifacts/README/CI workflow and expand integration+unit coverage

## Key Changes
- `AnalogicalGapDetector`
  - added namespace-stem and cross-family overlap signals/filters
  - cached per-source dependency list in scoring loop for better performance
  - kept `detect(graph, top_k=...)` compatibility while honoring explicit override
- New `evaluate_cli`
  - computes `topk_precision`, module-proxy `detection_rate`, `non_trivial_count`, and `go_no_go_status`
  - writes detailed decision checks and handles malformed JSON/CSV gracefully
  - keeps `top20_precision` as compatibility key only for `top_k=20`
- Pilot/CLI
  - dynamic label filename: `top{K}_label_template.csv`
  - friendlier missing-file errors in both detector and pilot CLIs
- CI
  - `setup-uv` bumped to `@v7`
  - explicit job timeout added

## Validation
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest -q`
- `uv run pytest -q -m integration`

All checks pass locally.
