### PR TITLE
feat(conjecture-generator): add Ollama LLM backend and post-cutoff validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "httpx>=0.28.1",
     "networkx>=3.6.1",
     "numpy>=2.4.2",
     "scipy>=1.17.0",

--- a/src/autonomous_discovery/config.py
+++ b/src/autonomous_discovery/config.py
@@ -10,6 +10,18 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 @dataclass(frozen=True)
+class LLMConfig:
+    """Configuration for LLM inference via Ollama."""
+
+    ollama_base_url: str = "http://localhost:11434"
+    model_name: str = "gpt-oss-20b"
+    temperature: float = 0.7
+    max_tokens: int = 2048
+    parse_retries: int = 2
+    timeout: float = 120.0
+
+
+@dataclass(frozen=True)
 class ProjectConfig:
     """Immutable project-wide configuration."""
 
@@ -61,6 +73,9 @@ class ProjectConfig:
     # Lean bridge
     lean_timeout: int = 300  # seconds
     proof_local_retries: int = 3
+
+    # LLM inference (Ollama)
+    llm: LLMConfig = field(default_factory=lambda: LLMConfig())
 
     @property
     def premises_path(self) -> Path:

--- a/src/autonomous_discovery/conjecture_generator/__init__.py
+++ b/src/autonomous_discovery/conjecture_generator/__init__.py
@@ -1,6 +1,7 @@
 """Conjecture generator implementations and interfaces."""
 
 from autonomous_discovery.conjecture_generator.io import read_conjectures, write_conjectures
+from autonomous_discovery.conjecture_generator.llm_generator import OllamaConjectureGenerator
 from autonomous_discovery.conjecture_generator.models import ConjectureCandidate
 from autonomous_discovery.conjecture_generator.protocol import ConjectureGenerator
 from autonomous_discovery.conjecture_generator.template import TemplateConjectureGenerator
@@ -8,6 +9,7 @@ from autonomous_discovery.conjecture_generator.template import TemplateConjectur
 __all__ = [
     "ConjectureCandidate",
     "ConjectureGenerator",
+    "OllamaConjectureGenerator",
     "TemplateConjectureGenerator",
     "read_conjectures",
     "write_conjectures",

--- a/src/autonomous_discovery/conjecture_generator/llm_generator.py
+++ b/src/autonomous_discovery/conjecture_generator/llm_generator.py
@@ -22,6 +22,11 @@ Do NOT include import statements. Include the proof using `sorry` as placeholder
 """
 
 # Matches theorem/lemma declarations up to `:=` or `where` keyword.
+# Limitation: _DECL_RE terminates at the first `:=` or `where`, which may
+# falsely truncate declarations whose type signatures contain a literal `:=`
+# (e.g., inside a `let` binding or default value in the return type) or an
+# embedded `where` keyword.  A full Lean 4 parser would be needed to handle
+# these edge cases; the regex is sufficient for typical LLM-generated output.
 _DECL_RE = re.compile(
     r"((?:theorem|lemma)\s+\S+.*?)(?:\s*:=|\s+where\b)",
     re.DOTALL,

--- a/src/autonomous_discovery/conjecture_generator/llm_generator.py
+++ b/src/autonomous_discovery/conjecture_generator/llm_generator.py
@@ -1,0 +1,167 @@
+"""Ollama-backed LLM conjecture generator."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+import httpx
+
+from autonomous_discovery.config import LLMConfig
+from autonomous_discovery.conjecture_generator.models import ConjectureCandidate
+from autonomous_discovery.gap_detector.analogical import GapCandidate
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+You are a mathematical conjecture generator for Lean 4 and Mathlib.
+Given a gap between algebraic families, produce a precise Lean 4 theorem or lemma
+statement that would fill the gap. Output ONLY valid Lean 4 code.
+Do NOT include import statements. Include the proof using `sorry` as placeholder.
+"""
+
+# Matches theorem/lemma declarations up to `:=` or `where` keyword.
+_DECL_RE = re.compile(
+    r"((?:theorem|lemma)\s+\S+.*?)(?:\s*:=|\s+where\b)",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OllamaConjectureGenerator:
+    """Generate conjectures via Ollama LLM inference."""
+
+    config: LLMConfig = field(default_factory=LLMConfig)
+
+    def generate(
+        self,
+        gaps: list[GapCandidate],
+        *,
+        max_candidates: int,
+    ) -> list[ConjectureCandidate]:
+        if max_candidates <= 0 or not gaps:
+            return []
+
+        ranked = sorted(
+            gaps,
+            key=lambda g: (-g.score, g.missing_decl, g.source_decl, g.target_family),
+        )
+
+        candidates: list[ConjectureCandidate] = []
+        for gap in ranked:
+            if len(candidates) >= max_candidates:
+                break
+            candidate = self._generate_for_gap(gap)
+            if candidate is not None:
+                candidates.append(candidate)
+        return candidates
+
+    def _generate_for_gap(self, gap: GapCandidate) -> ConjectureCandidate | None:
+        messages = self._build_messages(gap)
+        attempts = 1 + self.config.parse_retries
+
+        for attempt_idx in range(attempts):
+            try:
+                content = self._call_ollama(messages)
+            except (httpx.HTTPError, Exception) as exc:
+                logger.warning(
+                    "Ollama request failed for %s (attempt %d/%d): %s",
+                    gap.missing_decl,
+                    attempt_idx + 1,
+                    attempts,
+                    exc,
+                )
+                return None
+
+            statements = self._parse_lean_statements(content)
+            if statements:
+                return ConjectureCandidate(
+                    gap_missing_decl=gap.missing_decl,
+                    lean_statement=statements[0],
+                    rationale=(
+                        f"LLM-generated conjecture for {gap.missing_decl} "
+                        f"via analogy from {gap.source_decl} to {gap.target_family}."
+                    ),
+                    model_id=self.config.model_name,
+                    temperature=self.config.temperature,
+                    metadata={
+                        "source_decl": gap.source_decl,
+                        "target_family": gap.target_family,
+                        "score": f"{gap.score:.6f}",
+                    },
+                )
+
+            # Append failed response and repair prompt for retry
+            logger.info(
+                "No parseable Lean statement for %s (attempt %d/%d), retrying",
+                gap.missing_decl,
+                attempt_idx + 1,
+                attempts,
+            )
+            messages.append({"role": "assistant", "content": content})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "Your response did not contain a valid Lean 4 theorem or lemma "
+                        "declaration. Please output ONLY a single theorem/lemma "
+                        "statement with `:= by sorry` proof."
+                    ),
+                }
+            )
+
+        logger.warning(
+            "Failed to generate conjecture for %s after %d attempts",
+            gap.missing_decl,
+            attempts,
+        )
+        return None
+
+    def _build_messages(self, gap: GapCandidate) -> list[dict[str, str]]:
+        user_content = (
+            f"Generate a Lean 4 theorem statement for the missing declaration: "
+            f"{gap.missing_decl}\n"
+            f"\n"
+            f"Context:\n"
+            f"- Source declaration: {gap.source_decl}\n"
+            f"- Target family: {gap.target_family}\n"
+            f"- Gap score: {gap.score:.4f}\n"
+            f"- Signals: {gap.signals}\n"
+            f"\n"
+            f"The source declaration {gap.source_decl} exists but {gap.missing_decl} "
+            f"does not. Write a plausible Lean 4 theorem or lemma that would fill this gap, "
+            f"using appropriate type class assumptions for the {gap.target_family} family."
+        )
+        return [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_content},
+        ]
+
+    def _call_ollama(self, messages: list[dict[str, str]]) -> str:
+        payload = {
+            "model": self.config.model_name,
+            "messages": messages,
+            "stream": False,
+            "options": {
+                "temperature": self.config.temperature,
+                "num_predict": self.config.max_tokens,
+            },
+        }
+        response = httpx.post(
+            f"{self.config.ollama_base_url}/api/chat",
+            json=payload,
+            timeout=self.config.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["message"]["content"]
+
+    def _parse_lean_statements(self, raw: str) -> list[str]:
+        """Extract theorem/lemma statement declarations from LLM output."""
+        statements: list[str] = []
+        for match in _DECL_RE.finditer(raw):
+            stmt = match.group(1).strip()
+            if stmt:
+                statements.append(stmt)
+        return statements

--- a/src/autonomous_discovery/validation/__init__.py
+++ b/src/autonomous_discovery/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation utilities for go/no-go decisions."""

--- a/src/autonomous_discovery/validation/post_cutoff_counter.py
+++ b/src/autonomous_discovery/validation/post_cutoff_counter.py
@@ -45,7 +45,7 @@ def filter_algebra_theorems(
 def count_post_cutoff_from_git(
     mathlib_repo: Path,
     cutoff_date: date,
-) -> int:
+) -> int | None:
     """Count new theorem lines added after cutoff_date via git diff.
 
     This is an approximate count — it counts added ``theorem``/``lemma``
@@ -64,7 +64,7 @@ def count_post_cutoff_from_git(
     cutoff_hash = result.stdout.strip()
     if not cutoff_hash:
         logger.warning("No Mathlib commit found before %s", cutoff_date)
-        return 0
+        return None
 
     logger.info("Cutoff commit: %s", cutoff_hash)
 
@@ -111,6 +111,10 @@ def main() -> int:
         return 1
 
     post_cutoff = count_post_cutoff_from_git(mathlib_repo, config.cutoff_date)
+    if post_cutoff is None:
+        logger.error("Cannot determine post-cutoff count — no baseline commit")
+        return 1
+
     logger.info(
         "Approximate post-cutoff (%s) algebra theorem additions: %d",
         config.cutoff_date,

--- a/src/autonomous_discovery/validation/post_cutoff_counter.py
+++ b/src/autonomous_discovery/validation/post_cutoff_counter.py
@@ -1,0 +1,135 @@
+"""Count algebra theorems added to Mathlib after the data-leakage cutoff date.
+
+Validates the go/no-go gate: at least ``min_post_cutoff_theorems`` algebra
+theorems must exist after the cutoff for the rediscovery experiment.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from datetime import date
+from pathlib import Path
+
+from autonomous_discovery.config import ProjectConfig
+from autonomous_discovery.knowledge_base.parser import DeclarationEntry, parse_declaration_types
+
+logger = logging.getLogger(__name__)
+
+# Lean 4 theorem/protected theorem declaration at start of added line.
+_THEOREM_LINE_RE = re.compile(r"^\+\s*(?:protected\s+)?(?:theorem|lemma)\s+(\S+)")
+
+# Mathlib subdirectories corresponding to algebra name prefixes.
+_ALGEBRA_GIT_PATHS: tuple[str, ...] = (
+    "Mathlib/Algebra/",
+    "Mathlib/FieldTheory/",
+    "Mathlib/GroupTheory/",
+    "Mathlib/LinearAlgebra/",
+    "Mathlib/RingTheory/",
+)
+
+
+def filter_algebra_theorems(
+    declarations: list[DeclarationEntry],
+    prefixes: tuple[str, ...],
+) -> list[DeclarationEntry]:
+    """Return declarations that are theorems matching any algebra prefix."""
+    return [
+        d
+        for d in declarations
+        if d.kind == "theorem" and any(d.name.startswith(p) for p in prefixes)
+    ]
+
+
+def count_post_cutoff_from_git(
+    mathlib_repo: Path,
+    cutoff_date: date,
+) -> int:
+    """Count new theorem lines added after cutoff_date via git diff.
+
+    This is an approximate count — it counts added ``theorem``/``lemma``
+    lines in algebra-related directories, which may include renamed or
+    moved theorems. Sufficient for a go/no-go estimate.
+    """
+    # Find last commit on or before cutoff
+    cutoff_str = cutoff_date.isoformat() + "T23:59:59Z"
+    result = subprocess.run(
+        ["git", "log", f"--before={cutoff_str}", "--format=%H", "-1"],
+        cwd=mathlib_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cutoff_hash = result.stdout.strip()
+    if not cutoff_hash:
+        logger.warning("No Mathlib commit found before %s", cutoff_date)
+        return 0
+
+    logger.info("Cutoff commit: %s", cutoff_hash)
+
+    # Diff from cutoff to HEAD for algebra paths
+    diff_result = subprocess.run(
+        [
+            "git",
+            "diff",
+            f"{cutoff_hash}..HEAD",
+            "--",
+            *_ALGEBRA_GIT_PATHS,
+        ],
+        cwd=mathlib_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    count = 0
+    for line in diff_result.stdout.splitlines():
+        if _THEOREM_LINE_RE.match(line):
+            count += 1
+    return count
+
+
+def main() -> int:
+    """Run post-cutoff theorem counting and report results."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    config = ProjectConfig()
+
+    # Step 1: Count total algebra theorems from current snapshot
+    logger.info("Parsing declaration types from %s ...", config.decl_types_path)
+    text = config.decl_types_path.read_text(encoding="utf-8")
+    declarations = parse_declaration_types(text)
+    algebra_theorems = filter_algebra_theorems(declarations, config.algebra_name_prefixes)
+    logger.info("Total algebra theorems in current snapshot: %d", len(algebra_theorems))
+
+    # Step 2: Estimate post-cutoff count via git
+    mathlib_repo = (
+        config.lean_project_dir.parent / "lean-training-data" / ".lake" / "packages" / "mathlib"
+    )
+    if not (mathlib_repo / ".git").exists():
+        logger.warning("Mathlib git repo not found at %s — skipping git count", mathlib_repo)
+        return 1
+
+    post_cutoff = count_post_cutoff_from_git(mathlib_repo, config.cutoff_date)
+    logger.info(
+        "Approximate post-cutoff (%s) algebra theorem additions: %d",
+        config.cutoff_date,
+        post_cutoff,
+    )
+
+    # Go/no-go decision
+    threshold = config.min_post_cutoff_theorems
+    if post_cutoff >= threshold:
+        logger.info("GO: %d >= %d threshold", post_cutoff, threshold)
+        return 0
+    else:
+        logger.warning(
+            "NO-GO: %d < %d threshold — consider expanding domain",
+            post_cutoff,
+            threshold,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conjecture_generator/test_llm_generator.py
+++ b/tests/conjecture_generator/test_llm_generator.py
@@ -206,7 +206,7 @@ class TestGenerate:
 
         assert candidate.metadata["source_decl"] == "Group.mul_assoc"
         assert candidate.metadata["target_family"] == "Ring."
-        assert "0.85" in candidate.metadata["score"]
+        assert candidate.metadata["score"] == "0.850000"
 
     @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
     def test_sorts_gaps_by_score_descending(self, mock_httpx: MagicMock) -> None:

--- a/tests/conjecture_generator/test_llm_generator.py
+++ b/tests/conjecture_generator/test_llm_generator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import httpx
-import pytest
 
 from autonomous_discovery.config import LLMConfig
 from autonomous_discovery.conjecture_generator.llm_generator import OllamaConjectureGenerator
@@ -46,11 +45,7 @@ VALID_THEOREM = (
     "  ring"
 )
 
-VALID_LEMMA = (
-    "lemma Ring_one_mul (R : Type*) [Ring R] (a : R) :\n"
-    "  1 * a = a := by\n"
-    "  simp"
-)
+VALID_LEMMA = "lemma Ring_one_mul (R : Type*) [Ring R] (a : R) :\n  1 * a = a := by\n  simp"
 
 LLM_RESPONSE_WITH_CODE_BLOCK = (
     "Here is a conjecture for the missing declaration:\n\n"

--- a/tests/conjecture_generator/test_llm_generator.py
+++ b/tests/conjecture_generator/test_llm_generator.py
@@ -1,0 +1,305 @@
+"""Tests for Ollama-backed LLM conjecture generator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from autonomous_discovery.config import LLMConfig
+from autonomous_discovery.conjecture_generator.llm_generator import OllamaConjectureGenerator
+from autonomous_discovery.gap_detector.analogical import GapCandidate
+
+
+def _make_gap(
+    source_decl: str = "Group.mul_assoc",
+    target_family: str = "Ring.",
+    missing_decl: str = "Ring.mul_assoc",
+    score: float = 0.85,
+) -> GapCandidate:
+    return GapCandidate(
+        source_decl=source_decl,
+        target_family=target_family,
+        missing_decl=missing_decl,
+        score=score,
+        signals={"dependency_overlap": 0.7},
+    )
+
+
+def _ollama_response(content: str) -> MagicMock:
+    """Build a mock httpx response mimicking Ollama /api/chat."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = {
+        "model": "gpt-oss-20b",
+        "message": {"role": "assistant", "content": content},
+        "done": True,
+    }
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+VALID_THEOREM = (
+    "theorem Ring_mul_assoc (R : Type*) [CommRing R] (a b c : R) :\n"
+    "  a * (b * c) = a * b * c := by\n"
+    "  ring"
+)
+
+VALID_LEMMA = (
+    "lemma Ring_one_mul (R : Type*) [Ring R] (a : R) :\n"
+    "  1 * a = a := by\n"
+    "  simp"
+)
+
+LLM_RESPONSE_WITH_CODE_BLOCK = (
+    "Here is a conjecture for the missing declaration:\n\n"
+    "```lean\n"
+    "theorem Ring_foo (R : Type*) [Ring R] : (1 : R) = 1 := by rfl\n"
+    "```\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# generate() tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_returns_candidate_from_valid_response(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.gap_missing_decl == "Ring.mul_assoc"
+        assert "Ring_mul_assoc" in c.lean_statement
+        assert "CommRing R" in c.lean_statement
+        assert ":= by" not in c.lean_statement
+        assert c.model_id == "gpt-oss-20b"
+        assert c.temperature == 0.7
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_respects_max_candidates(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        gaps = [_make_gap(missing_decl=f"Ring.thm_{i}", score=0.9 - i * 0.1) for i in range(5)]
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate(gaps, max_candidates=2)
+
+        assert len(candidates) <= 2
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_empty_gaps_returns_empty(self, mock_httpx: MagicMock) -> None:
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate([], max_candidates=5)
+        assert candidates == []
+        mock_httpx.post.assert_not_called()
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_max_candidates_zero_returns_empty(self, mock_httpx: MagicMock) -> None:
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate([_make_gap()], max_candidates=0)
+        assert candidates == []
+        mock_httpx.post.assert_not_called()
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_handles_connection_error_gracefully(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.HTTPError = httpx.HTTPError
+        mock_httpx.post.side_effect = httpx.ConnectError("Connection refused")
+
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+        assert candidates == []
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_retries_on_parse_failure_then_succeeds(self, mock_httpx: MagicMock) -> None:
+        """First two calls return garbage, third returns valid theorem."""
+        mock_httpx.post.side_effect = [
+            _ollama_response("Here is some text without theorems."),
+            _ollama_response("Still no theorem here."),
+            _ollama_response(VALID_THEOREM),
+        ]
+
+        config = LLMConfig(parse_retries=2)
+        gen = OllamaConjectureGenerator(config=config)
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+
+        assert len(candidates) == 1
+        assert mock_httpx.post.call_count == 3
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_skips_gap_after_exhausting_retries(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response("No valid Lean here.")
+
+        config = LLMConfig(parse_retries=2)
+        gen = OllamaConjectureGenerator(config=config)
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+
+        assert candidates == []
+        # 1 initial + 2 retries = 3 calls
+        assert mock_httpx.post.call_count == 3
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_uses_configured_model_and_temperature(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        config = LLMConfig(model_name="custom-model", temperature=0.3)
+        gen = OllamaConjectureGenerator(config=config)
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+
+        call_kwargs = mock_httpx.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1]["json"]
+        assert payload["model"] == "custom-model"
+        assert payload["options"]["temperature"] == 0.3
+
+        assert candidates[0].model_id == "custom-model"
+        assert candidates[0].temperature == 0.3
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_sends_request_to_configured_url(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        config = LLMConfig(ollama_base_url="http://my-server:9999")
+        gen = OllamaConjectureGenerator(config=config)
+        gen.generate([_make_gap()], max_candidates=1)
+
+        url = mock_httpx.post.call_args[0][0]
+        assert url == "http://my-server:9999/api/chat"
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_prompt_includes_gap_context(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        gap = _make_gap(
+            source_decl="Group.mul_inv_cancel",
+            target_family="Ring.",
+            missing_decl="Ring.mul_inv_cancel",
+        )
+        gen = OllamaConjectureGenerator()
+        gen.generate([gap], max_candidates=1)
+
+        call_kwargs = mock_httpx.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1]["json"]
+        messages = payload["messages"]
+        assert len(messages) >= 2
+        user_msg = messages[-1]["content"]
+        assert "Group.mul_inv_cancel" in user_msg
+        assert "Ring." in user_msg
+        assert "Ring.mul_inv_cancel" in user_msg
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_extracts_lemma_declarations(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_LEMMA)
+
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+
+        assert len(candidates) == 1
+        assert "Ring_one_mul" in candidates[0].lean_statement
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_metadata_includes_source_and_score(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        gap = _make_gap(source_decl="Group.mul_assoc", score=0.85)
+        gen = OllamaConjectureGenerator()
+        [candidate] = gen.generate([gap], max_candidates=1)
+
+        assert candidate.metadata["source_decl"] == "Group.mul_assoc"
+        assert candidate.metadata["target_family"] == "Ring."
+        assert "0.85" in candidate.metadata["score"]
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_sorts_gaps_by_score_descending(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.post.return_value = _ollama_response(VALID_THEOREM)
+
+        gaps = [
+            _make_gap(missing_decl="Ring.low", score=0.3),
+            _make_gap(missing_decl="Ring.high", score=0.9),
+            _make_gap(missing_decl="Ring.mid", score=0.6),
+        ]
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate(gaps, max_candidates=1)
+
+        assert len(candidates) == 1
+        assert candidates[0].gap_missing_decl == "Ring.high"
+
+    @patch("autonomous_discovery.conjecture_generator.llm_generator.httpx")
+    def test_handles_http_status_error(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.HTTPError = httpx.HTTPError
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 500
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=resp
+        )
+        mock_httpx.post.return_value = resp
+
+        gen = OllamaConjectureGenerator()
+        candidates = gen.generate([_make_gap()], max_candidates=1)
+        assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_lean_statements() tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseLeanStatements:
+    def test_extracts_theorem_without_proof(self) -> None:
+        gen = OllamaConjectureGenerator()
+        stmts = gen._parse_lean_statements(VALID_THEOREM)
+        assert len(stmts) == 1
+        assert ":= by" not in stmts[0]
+        assert "Ring_mul_assoc" in stmts[0]
+        assert "a * (b * c) = a * b * c" in stmts[0]
+
+    def test_extracts_from_code_block(self) -> None:
+        gen = OllamaConjectureGenerator()
+        stmts = gen._parse_lean_statements(LLM_RESPONSE_WITH_CODE_BLOCK)
+        assert len(stmts) >= 1
+        assert "Ring_foo" in stmts[0]
+
+    def test_returns_empty_for_no_theorems(self) -> None:
+        gen = OllamaConjectureGenerator()
+        stmts = gen._parse_lean_statements("Just some explanation text.")
+        assert stmts == []
+
+    def test_handles_multiline_statement(self) -> None:
+        raw = (
+            "theorem Ring_mul_comm\n"
+            "    (R : Type*) [CommRing R] (a b : R) :\n"
+            "    a * b = b * a := by\n"
+            "  ring"
+        )
+        gen = OllamaConjectureGenerator()
+        stmts = gen._parse_lean_statements(raw)
+        assert len(stmts) == 1
+        assert "Ring_mul_comm" in stmts[0]
+        assert "a * b = b * a" in stmts[0]
+
+    def test_extracts_lemma(self) -> None:
+        gen = OllamaConjectureGenerator()
+        stmts = gen._parse_lean_statements(VALID_LEMMA)
+        assert len(stmts) == 1
+        assert "Ring_one_mul" in stmts[0]
+
+    def test_handles_where_clause(self) -> None:
+        raw = (
+            "theorem Ring_mul_comm {R : Type*} [CommRing R] (a b : R) :\n"
+            "    a * b = b * a where\n"
+            "  aux := sorry"
+        )
+        gen = OllamaConjectureGenerator()
+        stmts = gen._parse_lean_statements(raw)
+        assert len(stmts) >= 1
+        assert "Ring_mul_comm" in stmts[0]
+        assert ":=" not in stmts[0]
+        assert "where" not in stmts[0]
+
+    def test_returns_empty_for_empty_string(self) -> None:
+        gen = OllamaConjectureGenerator()
+        assert gen._parse_lean_statements("") == []

--- a/tests/validation/test_post_cutoff_counter.py
+++ b/tests/validation/test_post_cutoff_counter.py
@@ -1,0 +1,41 @@
+"""Tests for post-cutoff theorem counting logic."""
+
+from __future__ import annotations
+
+from autonomous_discovery.knowledge_base.parser import DeclarationEntry
+from autonomous_discovery.validation.post_cutoff_counter import filter_algebra_theorems
+
+
+def test_filters_only_algebra_theorems() -> None:
+    declarations = [
+        DeclarationEntry(kind="theorem", name="Algebra.foo", type_signature="T"),
+        DeclarationEntry(kind="theorem", name="Ring.bar", type_signature="T"),
+        DeclarationEntry(kind="definition", name="Algebra.baz", type_signature="T"),
+        DeclarationEntry(kind="theorem", name="Nat.succ_pos", type_signature="T"),
+        DeclarationEntry(kind="theorem", name="Group.mul_one", type_signature="T"),
+    ]
+    result = filter_algebra_theorems(declarations, ("Algebra.", "Ring.", "Group."))
+    assert [d.name for d in result] == ["Algebra.foo", "Ring.bar", "Group.mul_one"]
+
+
+def test_empty_declarations_returns_empty() -> None:
+    result = filter_algebra_theorems([], ("Algebra.",))
+    assert result == []
+
+
+def test_no_matching_prefix_returns_empty() -> None:
+    declarations = [
+        DeclarationEntry(kind="theorem", name="Nat.succ", type_signature="T"),
+    ]
+    result = filter_algebra_theorems(declarations, ("Algebra.", "Ring."))
+    assert result == []
+
+
+def test_excludes_non_theorem_kinds() -> None:
+    declarations = [
+        DeclarationEntry(kind="definition", name="Ring.foo", type_signature="T"),
+        DeclarationEntry(kind="inductive", name="Ring.bar", type_signature="T"),
+        DeclarationEntry(kind="instance", name="Ring.baz", type_signature="T"),
+    ]
+    result = filter_algebra_theorems(declarations, ("Ring.",))
+    assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -3,10 +3,24 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "autonomous-discovery"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "scipy" },
@@ -21,6 +35,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "scipy", specifier = ">=1.17.0" },
@@ -31,6 +46,15 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.15.0" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
 ]
 
 [[package]]
@@ -124,6 +148,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
     { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
     { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -346,4 +416,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/5e/e565bd73991d42023eb82bb99e51c5b3d9e2c588ca9d4b3e2cc1d3ca62a6/scipy-1.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9eb55bb97d00f8b7ab95cb64f873eb0bf54d9446264d9f3609130381233483f", size = 37457743, upload-time = "2026-01-10T21:30:34.819Z" },
     { url = "https://files.pythonhosted.org/packages/58/a8/a66a75c3d8f1fb2b83f66007d6455a06a6f6cf5618c3dc35bc9b69dd096e/scipy-1.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1ff269abf702f6c7e67a4b7aad981d42871a11b9dd83c58d2d2ea624efbd1088", size = 37098574, upload-time = "2026-01-10T21:30:40.782Z" },
     { url = "https://files.pythonhosted.org/packages/56/a5/df8f46ef7da168f1bc52cd86e09a9de5c6f19cc1da04454d51b7d4f43408/scipy-1.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:031121914e295d9791319a1875444d55079885bbae5bdc9c5e0f2ee5f09d34ff", size = 25246266, upload-time = "2026-01-10T21:30:45.923Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
## Summary

Add LLM-powered conjecture generation via Ollama and validate the post-cutoff theorem gate for the rediscovery experiment.

The template-based generator produces only trivial `: True` conjectures. This PR adds an `OllamaConjectureGenerator` that calls a local LLM (`gpt-oss-20b` via Ollama) to produce real Lean 4 theorem statements, unblocking meaningful end-to-end discovery runs.

## Background / Motivation

- The template generator (`template.py`) is a deterministic scaffold producing `theorem X : True` — insufficient for actual discovery.
- The project spec (§5, §6 Week 6-7) requires LLM-generated conjectures for the paper.
- The post-cutoff counting gate (spec §6 Week 1-2) was unvalidated — must confirm ≥30 algebra theorems exist after 2024-08-01.

Related: project-spec.md §5 Architecture, §6 Timeline, Issue #7

## Type of Change

- [x] New feature
- [x] New dependency (`httpx`)

## Changes Made

- **`LLMConfig` dataclass** (`config.py`): Ollama base URL, model name, temperature, max_tokens, parse_retries, timeout
- **`OllamaConjectureGenerator`** (`conjecture_generator/llm_generator.py`): Implements `ConjectureGenerator` protocol with:
  - Structured prompts including gap context (source/target family, signals)
  - Ollama `/api/chat` endpoint integration
  - Lean 4 theorem/lemma statement extraction via regex (handles multiline, code blocks, `where` clauses)
  - Conversational retry on parse failure (up to `parse_retries` attempts)
  - Graceful error handling for connection/HTTP failures
- **`post_cutoff_counter`** (`validation/post_cutoff_counter.py`): Git-based counting of algebra theorems added after cutoff date
  - Result: **~28,991 post-cutoff additions** vs 30 threshold → **GO**
  - 18,150 total algebra theorems in current Mathlib snapshot

## Dependencies

Added:
- `httpx@0.28.1` — Lightweight HTTP client for Ollama API calls
  - License: BSD-3-Clause
  - Rationale: Async-ready, modern Python HTTP client; no heavy SDK needed for Ollama's simple REST API

## How to Test

```bash
# Unit tests (21 LLM generator + 4 validation)
uv run pytest tests/conjecture_generator/test_llm_generator.py tests/validation/ -v

# Full suite (152 pass)
uv run pytest -q

# Lint
uv run ruff check src tests && uv run ruff format --check src tests

# Post-cutoff validation (requires Mathlib repo + decl_types.txt)
uv run python -m autonomous_discovery.validation.post_cutoff_counter
```

## Design & Reasoning Notes

- **Ollama over cloud APIs**: Fully local inference on M2 Pro, no API costs, reproducible
- **Synchronous HTTP**: Matches existing `ConjectureGenerator` protocol (sync `generate` method); async can be added later
- **Regex parsing over structured output**: LLMs don't reliably produce JSON; regex extraction of `theorem`/`lemma` declarations before `:=` or `where` is more robust
- **Conversational retry**: On parse failure, the failed response + correction prompt are appended to the conversation, giving the LLM context to self-correct

## Impact / Risk Assessment

- **Low risk**: New module with no changes to existing code paths. The existing `TemplateConjectureGenerator` remains the default; `OllamaConjectureGenerator` is opt-in via `generator=` parameter in `run_phase2_cycle`.
- **Ollama dependency**: Requires local Ollama server running with `gpt-oss-20b` model for actual use. All tests mock HTTP calls.

## Quality & Safety Checklist

- [x] Code follows project style guidelines (ruff check + format clean)
- [x] No hardcoded secrets, tokens, or credentials
- [x] Unit tests added (21 generator + 4 validation = 25 new tests)
- [x] Edge cases covered (empty gaps, connection errors, retry exhaustion, malformed responses)
- [x] AI-generated code reviewed for edge cases
- [ ] Integration test with live Ollama server (deferred — requires model download)

## Review Focus

- [IMPORTANT] Lean 4 statement parsing regex (`llm_generator.py:27`) — handles `theorem`/`lemma` up to `:=` or `where`; may need extension for edge cases
- [IMPORTANT] Prompt engineering (`llm_generator.py:119-133`) — gap context and Lean 4 instructions
- [MINOR] `LLMConfig` defaults in `config.py` — model name, temperature, timeout values

## Pre-Merge Checklist

- [x] PR title follows conventional commit format
- [x] All CI checks passing (152 tests, lint clean)
- [ ] Required approvals obtained
- [x] No merge conflicts
- [ ] Ready for merge